### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ![Project Logo](./assets/logo.png)
 
+<a href="https://glama.ai/mcp/servers/x4i8z2xmrq">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/x4i8z2xmrq/badge" alt="Firebase MCP server" />
+</a>
+
 ## Overview
 
 The [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) is an open protocol that enables seamless integration between LLM applications and external data sources and tools. This MCP server provides a standardized interface to interact with Firebase services including:


### PR DESCRIPTION
This PR adds a badge for the [Firebase MCP](https://glama.ai/mcp/servers/x4i8z2xmrq) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/x4i8z2xmrq">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/x4i8z2xmrq/badge" alt="Firebase MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.