### PR TITLE
fix: update Firestore collection listing to include error handling and improved logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2025-05-08
+
+### Fixed
+
+- Fixed critical JSON parsing error in `firestore_list_collections` tool
+- Added proper try/catch block to handle errors in collection listing
+- Enhanced error reporting for Firestore collection operations
+- Improved debug logging for collection listing operations
+
 ## [1.4.1] - 2025-05-08
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gannonh/firebase-mcp",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gannonh/firebase-mcp",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gannonh/firebase-mcp",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Firebase MCP server for interacting with Firebase services through the Model Context Protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1218,27 +1218,57 @@ class FirebaseMcpServer {
             }
           }
 
-          case 'firestore_list_collections':
-            const collections = await admin.firestore().listCollections();
-            const collectionList = collections.map(collection => ({
-              id: collection.id,
-              path: collection.path,
-            }));
+          case 'firestore_list_collections': {
+            try {
+              logger.debug('Listing Firestore collections');
+              const collections = await admin.firestore().listCollections();
+              const collectionList = collections.map(collection => ({
+                id: collection.id,
+                path: collection.path,
+              }));
 
-            // Ensure clean JSON by parsing and re-stringifying
-            const sanitizedJson = JSON.stringify({ collections: collectionList });
+              // Create a proper object structure
+              const result = { collections: collectionList };
 
-            // Log the response for debugging
-            const response = {
-              content: [
-                {
-                  type: 'text',
-                  text: sanitizedJson,
-                },
-              ],
-            };
-            logger.debug('firestore_list_collections response:', JSON.stringify(response));
-            return response;
+              // Ensure clean JSON by parsing and re-stringifying
+              const sanitizedJson = JSON.stringify(result);
+
+              // Log the response for debugging
+              const response = {
+                content: [
+                  {
+                    type: 'text',
+                    text: sanitizedJson,
+                  },
+                ],
+              };
+              logger.debug(
+                'firestore_list_collections success response:',
+                JSON.stringify(response)
+              );
+              return response;
+            } catch (error) {
+              logger.error('Error listing Firestore collections:', error);
+
+              // Ensure clean JSON by parsing and re-stringifying
+              const sanitizedJson = JSON.stringify({
+                error: 'Failed to list Firestore collections',
+                details: error instanceof Error ? error.message : 'Unknown error',
+              });
+
+              // Log the response for debugging
+              const response = {
+                content: [
+                  {
+                    type: 'text',
+                    text: sanitizedJson,
+                  },
+                ],
+              };
+              logger.debug('firestore_list_collections error response:', JSON.stringify(response));
+              return response;
+            }
+          }
 
           case 'firestore_query_collection_group': {
             const collectionId = args.collectionId as string;


### PR DESCRIPTION
## [1.4.2] - 2025-05-08

### Fixed

- Fixed critical JSON parsing error in `firestore_list_collections` tool
- Added proper try/catch block to handle errors in collection listing
- Enhanced error reporting for Firestore collection operations
- Improved debug logging for collection listing operations